### PR TITLE
use default database path for location.Database()

### DIFF
--- a/src/python/database.c
+++ b/src/python/database.c
@@ -48,8 +48,11 @@ static int Database_init(DatabaseObject* self, PyObject* args, PyObject* kwargs)
 	FILE* f = NULL;
 
 	// Parse arguments
-	if (!PyArg_ParseTuple(args, "s", &path))
+	if (!PyArg_ParseTuple(args, "|s", &path))
 		return -1;
+
+	if (!path)
+		path = strdup("@databasedir@/database.db");
 
 	// Copy path
 	self->path = strdup(path);


### PR DESCRIPTION
This is a naive sketch of the idea, since I've never written a Python module in C before.  Basically, I propose that there is a constructor `location.Database()` which uses a built-in default path, e.g. _/var/lib/location/database.db_ e.g. the value of `@databasedir@`.